### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/01-python-package.yml
+++ b/.github/workflows/01-python-package.yml
@@ -141,6 +141,8 @@ jobs:
   i18n:
     name: i18n
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/lt-mayonesa/hexagon/security/code-scanning/3](https://github.com/lt-mayonesa/hexagon/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `i18n` job. Based on the tasks performed by the job, it primarily interacts with repository contents (e.g., uploading artifacts). Therefore, the minimal required permission is `contents: read`. This ensures that the job does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
