### PR TITLE
fix(errors): show traceback on group tools

### DIFF
--- a/hexagon/runtime/execute/errors.py
+++ b/hexagon/runtime/execute/errors.py
@@ -105,11 +105,20 @@ class WithTracebackError(HexagonError):
             (
                 t
                 for t, path, file_name in cls.__walk_tb(tb)
-                if file_name == action_id
-                or path == os.path.join(custom_tools_path, action_id)
+                if cls.__executed_action_in_traceback(
+                    action_id, custom_tools_path, file_name, path
+                )
             ),
             None,
         )
+
+    @classmethod
+    def __executed_action_in_traceback(
+        cls, action_id, custom_tools_path, file_name, path
+    ):
+        action_name = action_id.split(".")[-1]
+        action_path = os.path.join(custom_tools_path, *action_id.split("."))
+        return file_name == action_name or path == action_path
 
     @classmethod
     def __walk_tb(cls, tb):

--- a/tests_e2e/__specs/execute_tool_2.py
+++ b/tests_e2e/__specs/execute_tool_2.py
@@ -93,6 +93,40 @@ def test_show_correct_error_when_execute_python_module_with_script_error():
     )
 
 
+def test_show_correct_error_when_execute_inner_python_module_with_script_error():
+    (
+        as_a_user(__file__)
+        .run_hexagon(["p-m-inner-script-error"])
+        .then_output_should_be(
+            [
+                "executed inner.p_m_inner_script_error",
+                "╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮",
+                {
+                    "expected": ["inner/p_m_inner_script_error.py:15"],
+                    "max_lines": 2,
+                    "line_delimiter": " │\n│ ",
+                },
+            ]
+        )
+        .then_output_should_be(
+            [
+                "12",
+                "13",
+                "14",
+                "15 │   err = [][3]",
+                "16",
+                "17",
+                "18",
+                "─────────────────────────────────────────────────────────────────────",
+                "IndexError: list index out of range",
+                "Execution of tool inner.p_m_inner_script_error failed",
+            ],
+            discard_until_first_match=True,
+        )
+        .exit(status=1)
+    )
+
+
 def test_show_correct_error_when_execute_python_module_with_script_error_and_no_custom_tools_dir():
     (
         as_a_user(__file__)

--- a/tests_e2e/execute_tool_2/app.yml
+++ b/tests_e2e/execute_tool_2/app.yml
@@ -104,3 +104,9 @@ tools:
     type: shell
     alias: pmse
     long_name: Python Module Script Error Test
+
+  - name: p-m-inner-script-error
+    action: inner.p_m_inner_script_error
+    type: shell
+    alias: pmise
+    long_name: Python Module Inner Script Error Test

--- a/tests_e2e/execute_tool_2/inner/p_m_inner_script_error.py
+++ b/tests_e2e/execute_tool_2/inner/p_m_inner_script_error.py
@@ -1,0 +1,24 @@
+from typing import Any, List, Optional
+
+from hexagon.domain.env import Env
+from hexagon.domain.tool import Tool
+
+
+def main(
+    action: Tool,
+    env: Optional[Env] = None,
+    env_args: Any = None,
+    cli_args: List[Any] = None,
+):
+    print(f"executed {action.action}")
+
+    err = [][3]
+    print(err)
+    if env_args:
+        print("Env args:")
+        print(env_args)
+
+    if cli_args and len(cli_args) > 0:
+        print("Cli args:")
+        for cli_arg in cli_args:
+            print(cli_arg)


### PR DESCRIPTION
When setting up group tools with python scripts inside python packages, the traceback logging was not working correctly.